### PR TITLE
ci: improve lint workflow trigger logic

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+      - ready_for_review
 
 jobs:
   client_eslint:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   client_eslint:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -23,6 +24,7 @@ jobs:
       - name: Lint
         run: npx eslint src
   client_prettier:
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -6,6 +6,7 @@ on:
       - opened
       - edited
       - synchronize
+      - ready_for_review
 
 jobs:
   main:


### PR DESCRIPTION
Lint workflows will now only when the PR is not in draft mode. Additionally lint workflows are now triggered when the PR is marked RFR.